### PR TITLE
Fix/safer error type check & single config location ($HOME/.config/sevp.toml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ This command displays the configuration for a specific target, including the `ta
 
 ### Custom Configuration: `~/.config/sevp.toml`
 
-SEVP uses a configuration file to define environment variables and their possible values. It looks for the config file in the following locations (in order of precedence):
-1. `$HOME/.config/sevp.toml` (default location)
-2. `$HOME/sevp.toml`
+SEVP uses a configuration file to define environment variables and their possible values: `$HOME/.config/sevp.toml`
 
 Here’s an example configuration:
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -67,7 +67,8 @@ func InitConfig() error {
 	if err := parseConfig(); err != nil {
 
 		// if no config file is found, create a default one
-		if err == err.(viper.ConfigFileNotFoundError) {
+		var configErr viper.ConfigFileNotFoundError
+		if errors.As(err, &configErr) {
 			slog.Debug("Config file not found, creating default config")
 			err := createDefaultConfig()
 			return err
@@ -123,10 +124,7 @@ func parseConfig() error {
 	viper.SetConfigName("sevp") // No dot here, Viper automatically adds extensions
 	viper.SetConfigType("toml")
 
-	// Add both possible config paths
-	// the .config takes precedence over the home directory
 	viper.AddConfigPath(path.Join(home, ".config")) // $HOME/.config/sevp.toml
-	viper.AddConfigPath(home)                       // $HOME/sevp.toml
 
 	// Read in the config
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
- `errors.AS` instead of type assertion when checking for existing config
- remove $HOME/sevp.toml as one of the possible config file locations