### PR TITLE
update: formula v1.0.4

### DIFF
--- a/HomebrewFormula/sevp.rb
+++ b/HomebrewFormula/sevp.rb
@@ -1,21 +1,21 @@
 class Sevp < Formula
   desc "A lightweight TUI for seamlessly switching environment variable values."
   homepage "https://github.com/masamerc/sevp"
-  version "1.0.3"
+  version "1.0.4"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/masamerc/sevp/releases/download/v1.0.3/sevp_1.0.3_darwin_arm64.tar.gz"
-      sha256 "15632f44b3c9fd06dfe3db2924add5a83a2be0fc33f4795d6aa703bf864ae925"
+      url "https://github.com/masamerc/sevp/releases/download/v1.0.4/sevp_1.0.4_darwin_arm64.tar.gz"
+      sha256 "b9abaf7ebd5194a60c0678a96e5eacc939e1d95912aa694692f29123a53c944b"
 
       def install
         bin.install "sevp"
       end
     end
     on_intel do
-      url "https://github.com/masamerc/sevp/releases/download/v1.0.3/sevp_1.0.3_darwin_amd64.tar.gz"
-      sha256 "96a5f87a33bf82c487a3091dfa28ceb5491273f65d797b448aaed823ca9aa70c"
+      url "https://github.com/masamerc/sevp/releases/download/v1.0.4/sevp_1.0.4_darwin_amd64.tar.gz"
+      sha256 "da4c2198ad1cfc4a7a369ff9f821f606284b297b61f3a031daced687ec4cc8d3"
 
       def install
         bin.install "sevp"
@@ -25,16 +25,16 @@ class Sevp < Formula
 
   on_linux do
     on_arm do
-      url "https://github.com/masamerc/sevp/releases/download/v1.0.3/sevp_1.0.3_linux_arm64.tar.gz"
-      sha256 "d6fb43962d607c18d6d103b135d704689dbab3786c2491ea578404840286cf32"
+      url "https://github.com/masamerc/sevp/releases/download/v1.0.4/sevp_1.0.4_linux_arm64.tar.gz"
+      sha256 "a5d07015c1264a7ee9d7b7db0578f74bcba7f0fb90c70d2ef7a0e14fa8cbed76"
 
       def install
         bin.install "sevp"
       end
     end
     on_intel do
-      url "https://github.com/masamerc/sevp/releases/download/v1.0.3/sevp_1.0.3_linux_amd64.tar.gz"
-      sha256 "b1125d06cd361c1d323da8a5791a2fa7c0ec48069d44e3fd2f432c65e156a31f"
+      url "https://github.com/masamerc/sevp/releases/download/v1.0.4/sevp_1.0.4_linux_amd64.tar.gz"
+      sha256 "ac802686e2c6991ce6579ead0c4a33eecd83081a922f39221f0562a8dad65959"
 
       def install
         bin.install "sevp"

--- a/scripts/update_formula.sh
+++ b/scripts/update_formula.sh
@@ -30,7 +30,10 @@ for PLATFORM in "${PLATFORMS[@]}"; do
 
   echo "Updating $PLATFORM in formula..."
   sed -i.bak -E "s#(url \")[^\"]*${PLATFORM}.tar.gz\"#\1$URL\"#" "$FORMULA_PATH"
-  sed -i.bak -E "/${PLATFORM}.tar.gz\"/{n;s#(sha256 \")[^\"]*\"#\1$SHA256\"#}" "$FORMULA_PATH"
+  awk -v url="$URL" -v sha="$SHA256" '
+    next_is_sha && /sha256/ { sub(/sha256 "[^"]*"/, "sha256 \"" sha "\""); next_is_sha=0 }
+    { if (index($0, url)) next_is_sha=1; print }
+  ' "$FORMULA_PATH" > "$FORMULA_PATH.tmp" && mv "$FORMULA_PATH.tmp" "$FORMULA_PATH"
 done
 
 rm -f "$FORMULA_PATH.bak"


### PR DESCRIPTION
Bumps Homebrew formula to v1.0.4. Also fixes `update_formula.sh` to use `awk` instead of GNU-only `sed {n;s}` so it works on
  macOS.